### PR TITLE
Set contact teaser header to h2 and remove "read more" link

### DIFF
--- a/kkb_contact/kkb_contact.admin.inc
+++ b/kkb_contact/kkb_contact.admin.inc
@@ -13,8 +13,6 @@ function kkb_contact_settings($form, &$form_state) {
   if (!isset($form_state['teasers'])) {
     $form_state['teasers'] = variable_get('kkb_contact_teasers', []);
   }
-  // Keep track of existing images.
-  $images = [];
 
   uasort($form_state['teasers'], 'drupal_sort_weight');
 
@@ -50,9 +48,6 @@ function kkb_contact_settings($form, &$form_state) {
   ];
 
   foreach ($form_state['teasers'] as $key => $teaser) {
-    if ($teaser['image']) {
-      $images[] = $teaser['image'];
-    }
     if (isset($teaser['deleted'])) {
       // We're keeping deleted items around to retain indexing (else form_error
       // gets into trouble), and because we might need to delete the image.
@@ -204,8 +199,6 @@ function kkb_contact_settings($form, &$form_state) {
     'js' => [drupal_get_path('module', 'kkb_contact') . '/kkb_contact.admin.js'],
   ];
 
-  $form_state['images'] = $images;
-
   $form['#validate'][] = 'kkb_contact_settings_validate';
   $form['#submit'][] = 'kkb_contact_settings_submit';
 
@@ -229,47 +222,6 @@ function kkb_contact_settings_validate($form, &$form_state) {
 function kkb_contact_settings_submit($form, &$form_state) {
   $teasers = [];
   $submitted_teasers = $form_state['values']['kkb_contact_teasers'];
-  $images = array_flip($form_state['images']);
-
-  // Delete images of deleted teasers.
-  foreach ($form_state['teasers'] as $key => $teaser) {
-    if (isset($teaser['deleted'])) {
-      if ($teaser['image']) {
-        $file = file_load($teaser['image']);
-        if ($file) {
-          file_usage_delete($file, 'kkb_contact', 'kkb_contact_teasers', $key, 0);
-          file_delete($file);
-        }
-        unset($images[$teaser['image']]);
-      }
-    }
-  }
-
-  foreach ($submitted_teasers as $key => $teaser) {
-    // If the image is new, make it permanent.
-    if ($teaser['image'] && !isset($images[$teaser['image']])) {
-      $file = file_load($teaser['image']);
-      $file->status = FILE_STATUS_PERMANENT;
-      file_save($file);
-      file_usage_add($file, 'kkb_contact', 'kkb_contact_teasers', $key);
-    }
-    else {
-      unset($images[$teaser['image']]);
-    }
-    $teasers[] = $teaser;
-  }
-
-  if (!empty($images)) {
-    // Delete dangling images. Replacing the image of a teaser before hitting
-    // save will replace the fid, but not delete the file.
-    foreach ($images as $image) {
-      $file = file_load($image);
-      if ($file) {
-        file_usage_delete($file, 'kkb_contact');
-        file_delete($file);
-      }
-    }
-  }
 
   uasort($teasers, 'drupal_sort_weight');
 
@@ -295,17 +247,6 @@ function kkb_contact_settings_teaser_form($teaser, $key) {
     '#type' => 'textarea',
     '#title' => t('Body'),
     '#default_value' => $teaser['body'],
-  ];
-
-  $form['image'] = [
-    '#title' => t('Image'),
-    '#type' => 'media',
-    '#media_options' => [
-      'global' => [
-        'types' => ['image'],
-      ],
-    ],
-    '#default_value' => $teaser['image'],
   ];
 
   $form['link'] = [
@@ -369,7 +310,6 @@ function kkb_contact_settings_add_one($form, &$form_state) {
   $form_state['teasers'][$key] = [
     'title' => '',
     'body' => '',
-    'image' => 0,
     'link' => '',
     'link_text' => '',
     'weight' => 0,

--- a/kkb_contact/kkb_contact.theme.inc
+++ b/kkb_contact/kkb_contact.theme.inc
@@ -15,19 +15,6 @@ function template_preprocess_kkb_contact_teaser(&$variables) {
   $variables['classes_array'][] = 'kkb-contact-box';
   $variables['classes_array'][] = $variables['zebra'];
 
-  $variables['image'] = '';
-  if ($teaser['image'] && ($file = file_load($teaser['image']))) {
-    $params = [
-      'style_name' => 'kkb_contact_teaser',
-      'path' => $file->uri,
-      'alt' => '',
-      'attributes' => [
-        'role' => 'presentation',
-      ],
-    ];
-    $variables['image'] = theme('image_style', $params);
-  }
-
   if ($teaser['link']) {
     $variables['title'] = l($teaser['title'], $teaser['link']);
     // Hide the read more link and the image from screen readers. The title link

--- a/kkb_contact/templates/kkb-contact-teaser.tpl.php
+++ b/kkb_contact/templates/kkb-contact-teaser.tpl.php
@@ -6,16 +6,8 @@
  */
 ?>
 <div class="<?php print $classes; ?>"<?php print $attributes; ?>>
-  <div class="image">
-    <?php print $image; ?>
-    </div>
-  <h3><?php print $title; ?></h3>
+  <h2><?php print $title; ?></h2>
   <div class="body">
     <?php print $body; ?>
-  </div>
-  <div class="buttons">
-    <div class="more-link">
-      <?php print $link; ?>
-    </div>
   </div>
 </div>

--- a/kkb_help/kkb_help.install
+++ b/kkb_help/kkb_help.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Delete images on contact teasers and remove the image if it no longer referenced.
+ */
+function kkb_help_update_7100() {
+  // Delete images of deleted teasers.
+  $teasers = variable_get('kkb_contact_teasers', []);
+  foreach ($teasers as $key => $teaser) {
+    if ($teaser['image']) {
+      $file = file_load($teaser['image']);
+      if ($file) {
+        file_usage_delete($file, 'kkb_contact', 'kkb_contact_teasers', $key, 0);
+        file_delete($file);
+      }
+    }
+  }
+}

--- a/kkb_help/kkb_help.install
+++ b/kkb_help/kkb_help.install
@@ -3,7 +3,7 @@
 /**
  * Delete images on contact teasers and remove the image if it no longer referenced.
  */
-function kkb_help_update_7100() {
+function kkb_help_update_7101() {
   // Delete images of deleted teasers.
   $teasers = variable_get('kkb_contact_teasers', []);
   foreach ($teasers as $key => $teaser) {
@@ -14,5 +14,7 @@ function kkb_help_update_7100() {
         file_delete($file);
       }
     }
+    unset($teaser['image']);
   }
+  variable_set('kkb_contact_teasers', $teasers);
 }


### PR DESCRIPTION
I set the headers and remove  the links (because later they will be removed in a restyling)
<img width="747" alt="Screenshot 2020-06-05 at 11 02 31" src="https://user-images.githubusercontent.com/1811751/83857995-16b36580-a71c-11ea-9f6c-f8f797ac39ce.png">
Later we will style it (in KKB-337), but this will make it WCAG appliant.
KKB-336 part 1