### PR TITLE
Make contact bottom block translatable

### DIFF
--- a/kkb_contact/kkb_contact.admin.inc
+++ b/kkb_contact/kkb_contact.admin.inc
@@ -9,6 +9,8 @@
  * Settings form builder.
  */
 function kkb_contact_settings($form, &$form_state) {
+  $node = menu_get_object();
+  $language = !empty($node) ? $node->language : 'da';
 
   if (!isset($form_state['teasers'])) {
     $form_state['teasers'] = variable_get('kkb_contact_teasers', []);
@@ -98,10 +100,16 @@ function kkb_contact_settings($form, &$form_state) {
     '#title' => t('Phone section'),
   ];
 
-  $form['phone_wrapper']['kkb_contact_page_phone_section_title'] = [
+  $form['phone_wrapper']['kkb_contact_page_phone_section_title_da'] = [
     '#type' => 'textfield',
-    '#title' => t('Section title'),
-    '#default_value' => variable_get('kkb_contact_page_phone_section_title', KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT),
+    '#title' => t('DA: Section title'),
+    '#default_value' => variable_get('kkb_contact_page_phone_section_title_' . $language, KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_DA),
+  ];
+
+  $form['phone_wrapper']['kkb_contact_page_phone_section_title_en'] = [
+    '#type' => 'textfield',
+    '#title' => t('EN: Section title'),
+    '#default_value' => variable_get('kkb_contact_page_phone_section_title_' . $language, KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_EN),
   ];
 
   $form['phone_wrapper']['first_box'] = [
@@ -128,10 +136,18 @@ function kkb_contact_settings($form, &$form_state) {
     '#format' => $left_box['format'],
   ];
 
-  $form['phone_wrapper']['first_box']['kkb_contact_page_phone_first_right_side'] = [
+  $form['phone_wrapper']['first_box']['kkb_contact_page_phone_first_right_side_da'] = [
     '#type' => 'textarea',
-    '#title' => t('Right'),
-    '#default_value' => variable_get('kkb_contact_page_phone_first_right_side', KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT),
+    '#title' => t('DA: Right'),
+    '#default_value' => variable_get('kkb_contact_page_phone_first_right_side_da', KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_DA),
+    '#cols' => 40,
+    '#rows' => 4,
+  ];
+
+  $form['phone_wrapper']['first_box']['kkb_contact_page_phone_first_right_side_en'] = [
+    '#type' => 'textarea',
+    '#title' => t('EN: Right'),
+    '#default_value' => variable_get('kkb_contact_page_phone_first_right_side_en', KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_EN),
     '#cols' => 40,
     '#rows' => 4,
   ];
@@ -156,6 +172,18 @@ function kkb_contact_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Section title'),
     '#default_value' => variable_get('kkb_contact_page_write_section_title', KKB_CONTACT_PAGE_WRITE_SECTION_TITLE_DEFAULT),
+  ];
+
+  $form['write_wrapper']['kkb_contact_page_write_da'] = [
+    '#type' => 'textfield',
+    '#title' => t('DA: Write'),
+    '#default_value' => variable_get('kkb_contact_page_write_da', KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_DA),
+  ];
+
+  $form['write_wrapper']['kkb_contact_page_write_en'] = [
+    '#type' => 'textfield',
+    '#title' => t('EN: Write'),
+    '#default_value' => variable_get('kkb_contact_page_write_en', KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_EN),
   ];
 
   foreach (['first' => t('First box'), 'second' => t('Second box')] as $box => $title) {
@@ -346,4 +374,8 @@ function kkb_contact_settings_delete($form, &$form_state) {
  */
 function kkb_contact_settings_callback(array $form, array &$form_state) {
   return $form['teasers_wrapper'];
+}
+
+function kkb_contact_variables_form() {
+  return drupal_get_form('variable_module_form', 'kkb_contact');
 }

--- a/kkb_contact/kkb_contact.module
+++ b/kkb_contact/kkb_contact.module
@@ -11,11 +11,26 @@ define('KKB_CONTACT_TEASERS_HEADER_VALUE_DEFAULT', '<p>Her kan du finde det, du 
 define('KKB_CONTACT_TEASERS_HEADER_FORMAT_DEFAULT', 'ding_wysiwyg');
 define('KKB_CONTACT_TEASERS_FOOTER_VALUE_DEFAULT', '<p>Du kan finde mere hjælp og information på <a href="/faq">FAQ siderne</a>.</p>');
 define('KKB_CONTACT_TEASERS_FOOTER_FORMAT_DEFAULT', 'ding_wysiwyg');
-define('KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT', 'Ring til Biblioteket Online');
+
+define('KKB_CONTACT_PAGE_PHONE_SECTION_BLOCK_TITLE_DEFAULT_DA', 'Har du stadigvæk brug for hjælp?');
+define('KKB_CONTACT_PAGE_PHONE_SECTION_BLOCK_TITLE_DEFAULT_EN', 'What do you need help with?');
+
+define('KKB_CONTACT_PAGE_PHONE_OPENING_HOURS_HEADER_DA', 'Telefontid');
+define('KKB_CONTACT_PAGE_PHONE_OPENING_HOURS_HEADER_EN', 'Opening hours');
+
+define('KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_DA', 'Ring til Biblioteket Online');
+define('KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_EN', 'Call the Library Online');
+
 define('KKB_CONTACT_PAGE_PHONE_FIRST_TITLE_DEFAULT', 'Kan du ikke finde svar sidder vi klar til at hjælpe med at svare på dine spørgsmål');
 define('KKB_CONTACT_PAGE_PHONE_FIRST_LEFT_SIDE_VALUE_DEFAULT', '<p>Telefontid i Bibliotek Online:</p>');
 define('KKB_CONTACT_PAGE_PHONE_FIRST_LEFT_SIDE_FORMAT_DEFAULT', 'ding_wysiwyg');
-define('KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT', "Mandag til torsdag fra 8:00 til 20:00\nFredag fra 8:00 til 18:00\nLørdag fra 10:00 til 14:00\nVihar lukket på søn- og helligdage.");
+
+define('KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_DA', "Mandag til torsdag fra 8:00 til 20:00\nFredag fra 8:00 til 18:00\nLørdag fra 10:00 til 14:00\nVihar lukket på søn- og helligdage.");
+define('KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_EN', "Monday to tuesday from 8:00 to 20:00\nFredag fra 8:00 til 18:00\nLørdag fra 10:00 til 14:00\nVihar lukket på søn- og helligdage.");
+
+define('KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_DA', 'Skriv');
+define('KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_EN', 'Write');
+
 define('KKB_CONTACT_PAGE_PHONE_SECOND_PHONE_DEFAULT', '3366 3000');
 define('KKB_CONTACT_PAGE_WRITE_SECTION_TITLE_DEFAULT', 'Skriv til Biblioteket Online');
 define('KKB_CONTACT_PAGE_WRITE_FIRST_TITLE_DEFAULT', 'Personfølsomme oplysninger');

--- a/kkb_contact/kkb_contact.pages.inc
+++ b/kkb_contact/kkb_contact.pages.inc
@@ -9,6 +9,9 @@
  * Page callback.
  */
 function kkb_contact_page() {
+  $node = menu_get_object();
+  $language = !empty($node) ? $node->language : 'da';
+
   $vars = [];
 
   $vars['page_title'] = variable_get('kkb_contact_page_title', KKB_CONTACT_PAGE_TITLE_DEFAULT);
@@ -50,7 +53,7 @@ function kkb_contact_page() {
   $vars['teasers_footer'] = check_markup($footer['value'], $footer['format']);
 
   // Phone section.
-  $vars['phone_section_title'] = variable_get('kkb_contact_page_phone_section_title', KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT);
+  $vars['phone_section_title'] = variable_get('kkb_contact_page_phone_section_title_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_EN);
   $vars['phone_first_box_title'] = variable_get('kkb_contact_page_phone_first_title', KKB_CONTACT_PAGE_PHONE_FIRST_TITLE_DEFAULT);
 
   $left_box = variable_get('kkb_contact_page_phone_first_left_side',
@@ -60,13 +63,13 @@ function kkb_contact_page() {
               ]);
 
   $vars['phone_first_left'] .= '<div>' . check_markup($left_box['value'], $left_box['format']) . '</div>';
-  $vars['phone_first_right'] = '<p>' . nl2br(variable_get('kkb_contact_page_phone_first_right_side', KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT)) . '</p>';
+  $vars['phone_first_right'] = '<p>' . nl2br(variable_get('kkb_contact_page_phone_first_right_side_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_EN)) . '</p>';
 
   $number = variable_get('kkb_contact_page_phone_second_phone', KKB_CONTACT_PAGE_PHONE_SECOND_PHONE_DEFAULT);
   $vars['phone_second_bottom'] .= l($number, 'tel:+45' . strtr($number, [' ' => '']), ['external' => TRUE]);
 
   // Write section.
-  $vars['write_section_title'] = variable_get('kkb_contact_page_write_section_title', KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT);
+  $vars['write_section_title'] = variable_get('kkb_contact_page_write_section_title_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_EN);
 
   foreach (['first', 'second'] as $box) {
     $box_content['title'] = variable_get('kkb_contact_page_write_' . $box . '_title', constant('KKB_CONTACT_PAGE_WRITE_' . strtoupper($box) . '_TITLE_DEFAULT'));

--- a/kkb_contact/kkb_contact.theme.inc
+++ b/kkb_contact/kkb_contact.theme.inc
@@ -68,13 +68,19 @@ function template_preprocess_kkb_contact_page(&$variables) {
  * Preprocess function for kkb_contact_block.
  */
 function template_preprocess_kkb_contact_block(&$variables) {
+  $node = menu_get_object();
+  $language = !empty($node) ? $node->language : 'da';
+
   drupal_add_css(drupal_get_path('module', 'kkb_contact') . '/css/kkb_contact.block.css');
   $number = variable_get(
     'kkb_contact_page_phone_second_phone',
     KKB_CONTACT_PAGE_PHONE_SECOND_PHONE_DEFAULT
   );
+  $variables['phone_header'] = variable_get('kkb_contact_page_phone_section_title_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_SECTION_TITLE_DEFAULT_EN);
   $variables['phone'] = l($number, 'tel:+45' . strtr($number, [' ' => '']), ['external' => TRUE]);
-  $variables['opening_hours'] = nl2br(variable_get('kkb_contact_page_phone_first_right_side', KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT));
+  $variables['opening_hours_header'] = variable_get('kkb_contact_page_phone_opening_hours_header_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_OPENING_HOURS_HEADER_DA : KKB_CONTACT_PAGE_PHONE_OPENING_HOURS_HEADER_EN);
+  $variables['opening_hours'] = nl2br(variable_get('kkb_contact_page_phone_first_right_side_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_FIRST_RIGHT_SIDE_DEFAULT_EN));
+  $variables['write'] = variable_get('kkb_contact_page_phone_write_' . $language, $language === 'da' ? KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_WRITE_DEFAULT_EN);
 }
 
 /**

--- a/kkb_contact/plugins/content_types/kkb_contact_footer.inc
+++ b/kkb_contact/plugins/content_types/kkb_contact_footer.inc
@@ -16,9 +16,13 @@ $plugin = [
  * Content type render function.
  */
 function kkb_contact_kkb_contact_footer_content_type_render() {
+  $node = menu_get_object();
+  $language = !empty($node) ? $node->language : 'da';
+  $title_default = $language === 'da' ? KKB_CONTACT_PAGE_PHONE_SECTION_BLOCK_TITLE_DEFAULT_DA : KKB_CONTACT_PAGE_PHONE_SECTION_BLOCK_TITLE_DEFAULT_EN;
+
   $block = new stdClass();
   // @todo should be translatable.
-  $block->title = 'Har du stadigvæk brug for hjælp?';
+  $block->title = variable_get('kkb_contact_page_phone_section_block_title_' . $language, $title_default);
   $block->content = [
     '#theme' => 'kkb_contact_block',
   ];

--- a/kkb_contact/templates/kkb-contact-block.tpl.php
+++ b/kkb_contact/templates/kkb-contact-block.tpl.php
@@ -6,13 +6,13 @@
  */
 ?>
 <section class="phone-section">
-  <h3>Ring til biblioteket online:</h3>
+  <h3><?php print $phone_header; ?>:</h3>
   <?php print $phone ?>
 </section>
 <section>
-  <h3>Telefontid:</h3>
+  <h3><?php print $opening_hours_header; ?>:</h3>
   <?php print $opening_hours ?>
 </section>
 <section>
-  <h3><a href="/kontakt#skriv">Skriv</a></h3>
+  <h3><a href="/kontakt#skriv"><?php print $write; ?></a></h3>
 </section>

--- a/kkb_contact/templates/kkb-contact-page.tpl.php
+++ b/kkb_contact/templates/kkb-contact-page.tpl.php
@@ -17,13 +17,13 @@
   </div>
   <div class="kkb-contact-section">
     <?php foreach ($teasers as $teaser) : ?>
-    <?php print $teaser; ?>
+      <?php print $teaser; ?>
     <?php endforeach; ?>
   </div>
   <div class="kkb-contact-section-footer">
     <?php print $teasers_footer; ?>
   </div>
-  
+
   <a class="anchor" name="ring"></a>
   <div class="kkb-contact-section-contact">
     <div class="kkb-contact-box">
@@ -34,12 +34,12 @@
       </div>
     </div>
     <div class="kkb-contact-phone-second kkb-contact-box">
-        <div class="kkb-contact-phone-second-number">
-            <?php print $phone_second_bottom; ?>
-        </div>
+      <div class="kkb-contact-phone-second-number">
+        <?php print $phone_second_bottom; ?>
+      </div>
     </div>
   </div>
-  
+
   <a class="anchor" name="skriv"></a>
   <h2><?php print $write_section_title ?></h2>
   <div class="kkb-contact-section">


### PR DESCRIPTION
I am doing the minimum here. The footer block uses some
of the same variables as the contact page. Those variables
are exposed in the admin page. The contact page (and the admin page)
er not translatable - So in order to make the footer work,
I expose the variables needed for that in the contact admin page.

Ie "DA: Section title" and "EN: Section title". Furthermore not all
variables on the admin page are translatable, which could cause some confusion.

KKB-340