### PR TITLE
KKB-465 / KKB-468 / KKB-471 / KKB-433 / KKB-466

### DIFF
--- a/kkb_cludo_search/kkb_cludo_search.module
+++ b/kkb_cludo_search/kkb_cludo_search.module
@@ -77,7 +77,7 @@ function _preprocess_cludo($variables) {
   // we get the language from the vars.
   // But 'kontakt'. 'soegeresultat' and 'searchresult'
   // have no type or language, so we have to deduce it ourself.
-  if ($variables['type'] === 'ding_help_front') {
+  if (!empty($variables['type']) && $variables['type'] === 'ding_help_front') {
     $language = $variables['language'];
     $add_cludo_search = TRUE;
   }

--- a/kkb_cludo_search/templates/kkb-cludo-search-page.tpl.php
+++ b/kkb_cludo_search/templates/kkb-cludo-search-page.tpl.php
@@ -29,7 +29,7 @@
     </div>
   <?php else: ?>
     <form id="cludo-search-form-english" role="search">
-      <input type="search" class="search-input" aria-label="Search" aria-describedby="autocomplete_hint" placeholder="What are you looking for help with?">
+      <input type="search" class="search-input" aria-label="Search" aria-describedby="autocomplete_hint" placeholder="Search our help pages">
       <button type="submit" class="search-button" id="search-button">Search</button>
     </form>
 

--- a/kkb_help/css/kkb_help.css
+++ b/kkb_help/css/kkb_help.css
@@ -140,6 +140,11 @@
   padding-right: 60px;
 }
 
+/* Add padding to label so the text will wrap before going under the foldout button. */
+.paragraphs-item-ding-help-page-accordion .fieldset-legend > a {
+  text-decoration: none;
+}
+
 /* Add a bit of spacing between the collapsible button and the content.  */
 .paragraphs-item-ding-help-page-accordion .fieldset-wrapper > *:first-child {
   margin-top: 26px;

--- a/kkb_newsletter_paragraphs/kkb_newsletter_paragraphs.module
+++ b/kkb_newsletter_paragraphs/kkb_newsletter_paragraphs.module
@@ -158,7 +158,7 @@ function kkb_newsletter_paragraphs_preprocess_entity(&$variables) {
         body.page-taxonomy-term .kkb_newsletter_content_wrapper,
         body.page-panels:not(.page-node) .kkb_newsletter_content_wrapper {
             padding: 30px 15px;
-        } 
+        }
         body.page-node .$identifier .kkb_newsletter_image_wrapper {
             background-image: url($image_rect_url);
         }
@@ -191,7 +191,7 @@ function kkb_newsletter_paragraphs_preprocess_entity(&$variables) {
         body.page-taxonomy-term .kkb_newsletter_image_wrapper,
         body.page-panels:not(.page-node) .kkb_newsletter_image_wrapper {
             padding: 30px 15px;
-        } 
+        }
         .kkb_newsletter_submit {
             padding: 12px 36px;
             border-radius: 4px;
@@ -202,16 +202,16 @@ function kkb_newsletter_paragraphs_preprocess_entity(&$variables) {
             margin-top: -10px;
         }
         body.page-taxonomy-term .kkb_newsletter_image_wrapper,
-        body.page-taxonomy-term .kkb_newsletter_image_caption, 
+        body.page-taxonomy-term .kkb_newsletter_image_caption,
         body.page-taxonomy-term .kkb_newsletter_image_caption_small,
         body.page-panels:not(.page-node) .kkb_newsletter_header,
-        body.page-panels:not(.page-node) .kkb_newsletter_image_caption, 
+        body.page-panels:not(.page-node) .kkb_newsletter_image_caption,
         body.page-panels:not(.page-node) .kkb_newsletter_image_caption_small
-         { 
+         {
             font-size: 30px;
         }
         body.page-node .kkb_newsletter_header,
-        body.page-node .kkb_newsletter_image_caption, 
+        body.page-node .kkb_newsletter_image_caption,
         body.page-node .kkb_newsletter_image_caption_small{
             font-size: 27px;
         }
@@ -249,7 +249,7 @@ function kkb_newsletter_paragraphs_preprocess_entity(&$variables) {
             }
             .$identifier .kkb_newsletter_header {
                 color: #464646;
-                font-size: 17px;
+                font-size: 17px !important;
             }
             .kkb_newsletter_image_wrapper {
                 display: none;

--- a/kkb_newsletter_paragraphs/kkb_newsletter_paragraphs.module
+++ b/kkb_newsletter_paragraphs/kkb_newsletter_paragraphs.module
@@ -118,7 +118,7 @@ function kkb_newsletter_paragraphs_preprocess_entity(&$variables) {
     $variables['long_description'] = '<p class="kbb_newsletter_description kbb_newsletter_long_description">' . $variables['field_newsletter_lng_description'][0]['value'] . '</p>';
     $submit_url = $variables['field_newsletter_submit_url'][0]['value'];
     $variables['submit_button'] = '<button onclick="document.querySelector(\'.kkb_newsletter_submit__link--' . $identifier . '\').click()" class="kkb_newsletter_submit">' . $variables['field_newsletter_submit'][0]['value'] . '</button>';
-    $variables['submit_link'] = '<a href="' . $submit_url . '" class="kkb_newsletter_submit__link--' . $identifier . ' kkb_newsletter_submit__link" />';
+    $variables['submit_link'] = '<a href="' . $submit_url . '" class="kkb_newsletter_submit__link--' . $identifier . ' kkb_newsletter_submit__link"></a>';
 
     $image_rect_url = image_style_url('newsletter_small_landscape', $variables['field_newsletter_image'][0]['uri']);
     $image_landscape_url = image_style_url('newsletter_landscape', $variables['field_landscape_image'][0]['uri']);

--- a/kkb_popup_dialog/js/dialog.js
+++ b/kkb_popup_dialog/js/dialog.js
@@ -28,8 +28,8 @@
       return null;
     }
 
-    const { wait, header, url, text, submitText } = settings;
-    const cookieName = `kkb_popup_dialog--${url.replace(/\W|\s/g, '')}`;
+
+    const { wait, header, url, text, submitText, cookieName } = settings;
 
     /**
      * Do not display if the user has already used or dismissed the dialog.

--- a/kkb_popup_dialog/kkb_popup_dialog.info
+++ b/kkb_popup_dialog/kkb_popup_dialog.info
@@ -1,4 +1,5 @@
 name = KKB Popup Dialog
 description = Make popup dialogs that can link to other pages.
 core = 7.x
+configure = admin/config/ding/popup
 package = KKB

--- a/kkb_popup_dialog/kkb_popup_dialog.install
+++ b/kkb_popup_dialog/kkb_popup_dialog.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Install file for kkb_popup_dialog.
+ */
+
+/**
+ * Whitelist current popup dialog 'velkommen'.
+ */
+function kkb_popup_dialog_update_7001() {
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  $cookie_name = 'kkb_popup_dialog--velkommen';
+
+  $ecc_settings['whitelisted_cookies'] = $ecc_settings['whitelisted_cookies'] ?? '';
+
+  $ecc_settings['whitelisted_cookies'] .= "\r\n" . $cookie_name;
+
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
+}

--- a/kkb_popup_dialog/kkb_popup_dialog.module
+++ b/kkb_popup_dialog/kkb_popup_dialog.module
@@ -3,6 +3,8 @@
  * @file kkb_popup_dialog.
  */
 
+define('KKB_POPUP_DIALOG_COOKIE_PREFIX', 'kkb_popup_dialog--');
+
 /**
  * Implements hook_init().
  */
@@ -55,11 +57,12 @@ function _ajax_display_dialog() {
   foreach ($values as $dialog) {
     if (drupal_match_path($pathname, $dialog['match'])) {
       return drupal_json_output([
-        'header' =>  $dialog['header'],
-        'text' =>  $dialog['text'],
-        'submitText' =>  $dialog['submit_text'],
-        'url' =>  $dialog['url'],
-        'wait' =>  $dialog['wait'],
+        'header' => $dialog['header'],
+        'text' => $dialog['text'],
+        'submitText' => $dialog['submit_text'],
+        'url' => $dialog['url'],
+        'wait' => $dialog['wait'],
+        'cookieName' => KKB_POPUP_DIALOG_COOKIE_PREFIX . $dialog['match'],
       ]);
     }
   }
@@ -168,6 +171,7 @@ function kkb_popup_dialog_settings_form($form, &$form_state) {
     ],
   ];
 
+  $form['#submit'][] = 'kkb_popup_dialog_settings_form_submit';
   $form['#validate'][] = 'kkb_popup_dialog_settings_form_validate';
 
   return system_settings_form($form);
@@ -180,6 +184,46 @@ function kkb_popup_dialog_settings_form_validate($form, &$form_state) {
   $form_state['values']['kkb_popup_dialog'] = array_filter($form_state['values']['kkb_popup_dialog'], function ($value) {
     return !empty($value['match']) && !empty($value['header']) && !empty($value['url']) && !empty($value['text']) && !empty($value['submit_text']);
   });
+}
+
+/**
+ * Form submit handler for the popup settings form.
+ *
+ * We want the cookie compliance to white-list our pop-up dialog cookie.
+ */
+function kkb_popup_dialog_settings_form_submit($form, &$form_state) {
+  if (empty($form_state['values']['kkb_popup_dialog'])) {
+    return;
+  }
+
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+
+  // Setting a fallback value of empty string, if no whitelisted cookies exist.
+  $ecc_settings['whitelisted_cookies'] = $ecc_settings['whitelisted_cookies'] ?? '';
+
+  $dialogs = $form_state['values']['kkb_popup_dialog'];
+
+  // Turning the current cookies string into an array.
+  $all_wl_cookies = explode("\r\n", $ecc_settings['whitelisted_cookies']);
+
+  // Looping through the dialogs, and setting our cookie name as white-listed.
+  foreach ($dialogs as $dialog) {
+    if (empty($dialog['match'])) {
+      continue;
+    }
+
+    // Using drupal_clean_css_identifier to clean the string of anything
+    // unwanted that we wouldnt want the cookie to look like.
+    $all_wl_cookies[] = KKB_POPUP_DIALOG_COOKIE_PREFIX . drupal_clean_css_identifier($dialog['match']);
+  }
+
+  // Remove any duplicates - which can happen if we've saved this form
+  // multiple times.
+  $all_wl_cookies = array_unique($all_wl_cookies);
+
+  $ecc_settings['whitelisted_cookies'] = implode("\r\n", $all_wl_cookies);
+
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
 }
 
 /**

--- a/kkb_popup_dialog/kkb_popup_dialog.module
+++ b/kkb_popup_dialog/kkb_popup_dialog.module
@@ -284,7 +284,7 @@ function kkb_popup_dialog_preprocess_panels_pane(&$variables) {
  * Example: [{ "match": "hjaelp/gebyr-og-erstatning", "url": "//:somekey/url"
  * }]
  */
-function _display_popup_dialogs(&$variables) {
+function _display_popup_dialogs() {
   drupal_add_js('//unpkg.com/react@17.0.1/umd/react.production.min.js', [
     'type' => 'external',
     'weight' => -5,

--- a/kkb_wayfinder/css/kkb_wayfinder.css
+++ b/kkb_wayfinder/css/kkb_wayfinder.css
@@ -12,3 +12,12 @@
     width: 48.7%;
   }
 }
+
+.kkb-wayfinder--button.open-overlay .buttons {
+  width: 100% !important;
+}
+
+.kkb-wayfinder--button .trigger {
+  color: #000;
+  background: #fff;
+}

--- a/kkb_wayfinder/kkb_wayfinder.info
+++ b/kkb_wayfinder/kkb_wayfinder.info
@@ -1,5 +1,6 @@
-name = Kkb Wayfinder
-description = Add button to find material in library
+name = KKB Wayfinder
+description = Add button to find material in library, using a map popup.
 core = 7.x
 package = KKB
 dependencies[] = ding_availability
+configure = admin/config/ding/wayfinder

--- a/kkb_wayfinder/kkb_wayfinder.module
+++ b/kkb_wayfinder/kkb_wayfinder.module
@@ -83,7 +83,7 @@ function kkb_wayfinder_ding_entity_buttons($type, $entity) {
 /**
  * Preprocess kkb_wayfinder_button.
  */
-function template_preprocess_kkb_wayfinder_button(&$variables) {
+function kkb_wayfinder_preprocess_kkb_wayfinder_button(&$variables) {
   $variables['classes_array'] = array(
     'kkb-wayfinder--button',
     // Legacy: Use classes from now obsolete ding_list module.
@@ -103,21 +103,6 @@ function template_preprocess_kkb_wayfinder_button(&$variables) {
     '#attributes' => array(
       'class' => array('buttons'),
     ),
-    '#attached' => array(
-      'library' => array(array('system', 'drupal.ajax')),
-      'css' => array(
-        drupal_get_path('module', 'kkb_wayfinder') . '/css/kkb_wayfinder.buttons.min.css',
-        drupal_get_path('module', 'kkb_wayfinder') . '/css/kkb_wayfinder.css',
-      ),
-      'js' => array(
-        drupal_get_path('module', 'kkb_wayfinder') . '/js/kkb_wayfinder.buttons.js',
-        drupal_get_path('module', 'kkb_wayfinder') . '/js/kkb_wayfinder.js',
-        array(
-          'data' => variable_get('kkb_wayfinder_url', ''),
-          'type' => 'external',
-        ),
-      ),
-    ),
   );
 
   $variables['single_link'] = FALSE;
@@ -126,4 +111,21 @@ function template_preprocess_kkb_wayfinder_button(&$variables) {
   foreach ($options as $option) {
     $variables['buttons']['#links'][] = $option['custom'];
   }
+}
+
+function kkb_wayfinder_preprocess_html(&$variables) {
+  $wayfinder_url = variable_get('kkb_wayfinder_url', NULL);
+
+  if ($wayfinder_url) {
+    drupal_add_js($wayfinder_url, 'external');
+  }
+
+  drupal_add_library('system', 'drupal.ajax');
+
+
+  drupal_add_js(drupal_get_path('module', 'kkb_wayfinder') . '/js/kkb_wayfinder.buttons.js');
+  drupal_add_js(drupal_get_path('module', 'kkb_wayfinder') . '/js/kkb_wayfinder.js');
+
+  drupal_add_css(drupal_get_path('module', 'kkb_wayfinder') . '/css/kkb_wayfinder.buttons.min.css');
+  drupal_add_css(drupal_get_path('module', 'kkb_wayfinder') . '/css/kkb_wayfinder.css');
 }


### PR DESCRIPTION
(Best reviewed, commit by commit)


### **Dont underline legends in accordion. KKB-465**

---

### **Add link from modules page to KKB popup dialog settings.**

---

### **White-listing kkb_popup_dialog cookies. KKB-468**

These cookies do not hold any user-confidental data
and can freely be white-listed in EU cookie complicance.

Sadly, there's no way to use wildcards in EU cookie compliance,
so I've done the next "best" thing, and add the cookie names
to the white-list data when the kkb_popup_dialog gets saved.

---

### **Change cludo EN placeholder. KKB-471**

---

### **Get rid of PHP warnings in the log.**

---

### **Tweak font-size for mobile view. KKB-433**

There is a lot of rules/selectors above that go very deep.
!important has a quite direct purpose here - otherwise it will
be way too hard to maintain.

---

### **Move wayfinder assets from #attach to drupal_add_*. KKB-466**

For some ungodly reason, Drupal refuses to add
assets when they're being attached through AJAX.
Before this commit, the wayfinder worked on URLs like
ting/object/870970-basis%3A46687752 where the assets were
added on page-load, but it was broken on pages where
entities were loaded with AJAX such as lists.

I've tried a million things and nothing works, so this
is the ultimate hammer: Addings the assets on all pages.
I've checked the assets, and they're not gigantic, so
it's not the end of the world.