### PR TITLE
Make help steps tabbable and clickable with the return key

### DIFF
--- a/kkb_help/js/kkb_help.steps.js
+++ b/kkb_help/js/kkb_help.steps.js
@@ -21,26 +21,59 @@
       $('.js-step-items').once(function () {
         var items = $(this);
 
+        var allToggle = function (item) {
+          item.toggleClass('step-shown');
+          updateAllToggle(items);
+        };
+
+        var stepShow = function () {
+          $('.js-step-item', items).addClass('step-shown');
+          updateAllToggle(items);
+        };
+
+        var stepHide = function () {
+          $('.js-step-item', items).removeClass('step-shown');
+          updateAllToggle(items);
+        };
+
+        var handleKeycode = function(event, callback) {
+            // Return key
+            if(event.keyCode === 13){
+              callback();
+            }
+        };
+
         $('.js-step-item', items).each(function () {
           var content = $('.js-step-content', this);
           var item = $(this);
-          $('.js-step-title', this).after(' <span class="show">' + Drupal.t('Show') + '</span>');
-          $('.js-step-title', this).after(' <span class="hide">' + Drupal.t('Hide') + '</span>');
-          $('.js-step-header', this).click(function () {
-            item.toggleClass('step-shown');
-            updateAllToggle(items);
-          });
+          $('.js-step-title', this).after(' <span class="show" tabindex="0">' + Drupal.t('Show') + '</span>');
+          $('.js-step-title', this).after(' <span class="hide" tabindex="0">' + Drupal.t('Hide') + '</span>');
+          $('.js-step-header', this)
+            .click(function() {
+              allToggle(item);
+            })
+            .on('keyup', function(event) {
+              handleKeycode(event, function() {
+                allToggle(item);
+              });
+            });
         });
 
         var show_hide_all = $('<div class="show-hide-all"></div>');
-        show_hide_all.append($(' <span class="show-all">' + Drupal.t('Show all') + '</span>').click(function () {
-          $('.js-step-item', items).addClass('step-shown');
-          updateAllToggle(items);
-        }));
-        show_hide_all.append($(' <span class="hide-all">' + Drupal.t('Hide all') + '</span>').click(function () {
-          $('.js-step-item', items).removeClass('step-shown');
-          updateAllToggle(items);
-        }));
+
+        show_hide_all.append($(' <span class="show-all" tabindex="0">' + Drupal.t('Show all') + '</span>')
+          .on('click', stepShow)
+          .on('keyup', function(event) {
+            handleKeycode(event, stepShow);
+          })
+        );
+
+        show_hide_all.append($(' <span class="hide-all" tabindex="0">' + Drupal.t('Hide all') + '</span>')
+          .on('click', stepHide)
+          .on('keyup', function(event) {
+            handleKeycode(event, stepHide);
+          })
+        );
 
         $(this).before(show_hide_all);
         updateAllToggle(items);


### PR DESCRIPTION
KKB-488

* Make the steps tabbable by adding tabindex="0"
* Make the steps clickable (show/hide) by reacting to the user clicking the return key.  

Question for the reviewer: There are combinations of clicking a link, like cmd+return, which will also trigger the show/hide toggling. I think this is the only way to click on something with the keyboard?