### PR TITLE
Feature/kkb 489 2

### DIFF
--- a/kkb_help/css/kkb_help.css
+++ b/kkb_help/css/kkb_help.css
@@ -152,6 +152,13 @@
 
 .ding-help-page-accordion__title {
   font-size: 18px;
+  border: none;
+  background-color: transparent;
+  font-family: FaktPro-SemiBold,sans-serif;
+  line-height: 28px;
+  margin-bottom: 20px;
+  font-weight: 700;
+  cursor: pointer;
 }
 
 /* Style ol on help page as step directions. */

--- a/kkb_help/js/kkb_help.steps.js
+++ b/kkb_help/js/kkb_help.steps.js
@@ -4,6 +4,42 @@
  */
 
 (function ($) {
+  'use strict';
+
+  // Since .fieldset-title is appended to the accordion by misc/collapse.js
+  // we need to wait for it in the dom, before doing anything else.
+  var waitForFieldsetTitle = function($item, cb) {
+    // If its already there, return early.
+    if ($item.find('.fieldset-title').length) {
+      return cb();
+    }
+
+    // Wait for the fieldset-title to be inserted, then disable the observer
+    // and call the callback.
+    let observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (!mutation.addedNodes) {
+          return;
+        }
+
+        for (let i = 0; i < mutation.addedNodes.length; i++) {
+          let node = mutation.addedNodes[i];
+          if (node.classList && node.classList.contains('fieldset-title')) {
+            observer.disconnect();
+            return cb();
+          }
+        }
+      });
+    });
+
+    observer.observe($item.get(0), {
+      childList: true
+      , subtree: true
+      , attributes: false
+      , characterData: false
+    });
+  };
+
   var updateAllToggle = function (items) {
     var not_shown = $('.js-step-item:not(.step-shown)', items);
     if (not_shown.length > 0) {
@@ -17,17 +53,63 @@
   };
 
   Drupal.behaviors.kkb_help_steps = {
-    attach: function (context) {
-      $('.collapsible .fieldset-title').once(function() {
-        this.setAttribute('aria-button', true);
-        $(this).on('click', function() {
-          if (this.hasAttribute('open')) {
-            this.removeAttribute('open');
-            this.setAttribute('aria-expanded', false);
-          } else {
-            this.setAttribute('open', '');
-            this.setAttribute('aria-expanded', true);
-          }
+    attach: function () {
+      $('.paragraphs-item-ding-help-page-accordion').once(function(accordion_idx) {
+        var $this = $(this);
+        // These are used to tell the accordion what kind of behaviour it can have.
+        $this.attr('data-allow-toggle');
+        $this.attr('data-allow-multiple');
+
+        waitForFieldsetTitle($this, function() {
+
+          $this.find('.fieldset-wrapper').each(function(idx, wrapper) {
+            var $wrapper = $(wrapper);
+            $wrapper.attr('id', 'fieldset-wrapper--' + accordion_idx + '--'  + idx);
+            $wrapper.attr('aria-labelledby', 'ding-help-page-accordion__title--' + accordion_idx + '--' + idx);
+            $wrapper.attr('role', 'region');
+          });
+
+          // Make the accordion title accessible by changing it to an aria enabled button.
+          $this.find('.ding-help-page-accordion__title').each(function(idx, title) {
+            // Copy the title classes over to a new button element.
+            var $title = $(title);
+            var classes = $title.attr('class');
+            var $button = $('<button class="' + classes + '">' + $title.html() + '</button>');
+
+            // Make it compliant with wcag accordions.
+            $button.attr('id', 'ding-help-page-accordion__title--' + accordion_idx + '--'  + idx);
+            $button.attr('aria-controls', 'fieldset-wrapper--' + accordion_idx + '--'  + idx);
+            $button.attr('aria-expanded', false);
+            $button.attr('aria-role', 'button');
+
+            // Insert the button instead of the title.
+            $title.replaceWith($button);
+
+            // After inserting the button, we need to find it in the document
+            // and switch its expanded state. This is because after using replaceWith
+            // you cannot add an on click handler directly on the button.
+            $(document).on('click', '#ding-help-page-accordion__title--' + accordion_idx + '--' + idx, function() {
+              $(this).attr('aria-expanded', $(this).attr('aria-expanded') === 'false');
+
+              // This is copied over from misc/collapse.js, since the button is
+              // not hooked up to collapse.js.
+              var fieldset = $this.find('.collapsible').get(0);
+              // Don't animate multiple times.
+              if (!fieldset.animating) {
+                fieldset.animating = true;
+                // Call toggleFieldset in misc/collapse.js
+                Drupal.toggleFieldset(fieldset);
+              }
+            });
+          });
+
+          // fieldset-title should be changed from an 'a' tag to an 'h2' tag.
+          // We do this because we do not want the button to be wrapped in an 'a',
+          // this would cause screen readers to see the button as both a link
+          // and a button.
+          $this.find('.fieldset-title').each(function(idx, title) {
+            $(title).replaceWith('<h2 class="fieldset-title">' + $(title).html() + '</h2>');
+          });
         });
       });
 
@@ -52,7 +134,7 @@
         $('.js-step-item', items).each(function () {
           var content = $('.js-step-content', this);
           var item = $(this);
-          $('.js-step-title', this).after(' <button class="help-button--text show">' + Drupal.t('Show') + '</button>');
+          $('.js-step-title', this).after(' <button class="help-button--text">' + Drupal.t('Show') + '</button>');
           $('.js-step-title', this).after(' <button class="help-button--text hide">' + Drupal.t('Hide') + '</button>');
           $('.js-step-header', this).click(function() {
               allToggle(item);

--- a/kkb_help/kkb_help.module
+++ b/kkb_help/kkb_help.module
@@ -278,7 +278,10 @@ function kkb_help_preprocess_entity(&$variables) {
           '#collapsed' => TRUE,
           // The above is not enough to get collapsibles working (core bug), so
           // add attributes and JS.
-          '#attributes' => array('class' => array('collapsible', 'collapsed')),
+          '#attributes' => array(
+            'class' => array('collapsible', 'collapsed'),
+            'aria-hidden' => TRUE,
+          ),
           '#attached' => array('js' => array('misc/collapse.js', 'misc/form.js')),
           'body' => array(
             '#markup' => check_markup($body['value'], $body['format']),


### PR DESCRIPTION
Make kkb_help accordions accessible.

After making this task, I think there is a better way to do it: copy over (or patch) `misc/collapse.js` then make that WACG compliant.

Anyways, the solution as it is now goes like this:

* In kkb_help.steps.js we need to wait for `a.fieldset-title` to be inserted into the dom. We do that with an oberser.
* Then we need to make the fieldset wrappers compliant by giving them some aria attributes.
* Then the accordion headers, which are links, should be turned into buttons and also be WCAG compliant.
* Finally we need to manually trigger `toggleFieldset` in `misc/collapse` on clicking the buttons.

Styling has been fixed since making the video below:


https://user-images.githubusercontent.com/1811751/141463949-bbe38b56-f3f2-4640-98b1-6c8249f75641.mp4


