### PR TITLE
Style kkb_help step buttons as links

### DIFF
--- a/kkb_help/css/kkb_help.steps.css
+++ b/kkb_help/css/kkb_help.steps.css
@@ -11,6 +11,11 @@
 .show-hide-all .show-all,
 .show-hide-all .hide-all {
   color: #3a6f55;
+  font-size: 16px;
+  border: none;
+  background-color: transparent;
+  padding: 0;
+  cursor: pointer;
 }
 
 .show-hide-all {


### PR DESCRIPTION
Se dette screenshot:
![Screenshot 2021-11-12 at 11 59 58](https://user-images.githubusercontent.com/1811751/141456602-1509edb6-dd59-4e46-976c-dd57d2dbfbd3.png)

Versus: 
![markingOmLinks](https://user-images.githubusercontent.com/1811751/141456703-9c3a822b-9c30-4105-b3b8-ee2fccc591e7.png)

KKB-492