### PR TITLE
Generate a better cookie name

### DIFF
--- a/kkb_popup_dialog/kkb_popup_dialog.module
+++ b/kkb_popup_dialog/kkb_popup_dialog.module
@@ -56,13 +56,21 @@ function _ajax_display_dialog() {
   $values = variable_get('kkb_popup_dialog');
   foreach ($values as $dialog) {
     if (drupal_match_path($pathname, $dialog['match'])) {
+      // Use the first of the paths to match (it ought to be unique, if it isn't,
+      // you asked for it), trim it (might still contain \r
+      // and other fluff) and urlencode it. Browsers should allow pretty much
+      // anything, but be a bit inconsistent about it, so urlencoding is
+      // recommended. See
+      // https://stackoverflow.com/questions/1969232/what-are-allowed-characters-in-cookies
+      $cookie_id = explode("\n", $dialog['match']);
+      $cookie_id = urlencode(trim(reset($cookie_id)));
       return drupal_json_output([
         'header' => $dialog['header'],
         'text' => $dialog['text'],
         'submitText' => $dialog['submit_text'],
         'url' => $dialog['url'],
         'wait' => $dialog['wait'],
-        'cookieName' => KKB_POPUP_DIALOG_COOKIE_PREFIX . $dialog['match'],
+        'cookieName' => KKB_POPUP_DIALOG_COOKIE_PREFIX . $cookie_id,
       ]);
     }
   }


### PR DESCRIPTION
Just taking the match paths settings verbatim as the cookie name was
bound to fail. Even in a simple case, one might end up with "<some
path>\r\n", which would make the React setCookie() function throw a
fit (rightfully).

Ref KKB-508